### PR TITLE
Updated docs.

### DIFF
--- a/docs/co2sys_nd.md
+++ b/docs/co2sys_nd.md
@@ -118,15 +118,15 @@ Each argument to `pyco2.sys` described on this page can either be a single scala
         * `6`: [MCHP73](../refs/#m) aka "GEOSECS" (2 < *T* < 35 °C, 19 < *S* < 43, NBS scale, real seawater).
         * `7`: [MCHP73](../refs/#m) without certain species aka "Peng" (2 < *T* < 35 °C, 19 < *S* < 43, NBS scale, real seawater).
         * `8`: [M79](../refs/#m) (0 < *T* < 50 °C, *S* = 0, freshwater only).
-        * `9`: [CW98](../refs/#c) (2 < *T* < 35 °C, 0 < *S* < 49, NBS scale, real and artificial seawater).
+        * `9`: [CW98](../refs/#c) (2 < *T* < 30 °C, 0 < *S* < 40, NBS scale, real seawater).
         * `10`: [LDK00](../refs/#l) (2 < *T* < 35 °C, 19 < *S* < 43, Total scale, real seawater).
         * `11`: [MM02](../refs/#m) (0 < *T* < 45 °C, 5 < *S* < 42, Seawater scale, real seawater).
         * `12`: [MPL02](../refs/#m) (−1.6 < *T* < 35 °C, 34 < *S* < 37, Seawater scale, field measurements).
         * `13`: [MGH06](../refs/#m) (0 < *T* < 50 °C, 1 < *S* < 50, Seawater scale, real seawater).
         * `14`: [M10](../refs/#m) (0 < *T* < 50 °C, 1 < *S* < 50, Seawater scale, real seawater).
-        * `15`: [WMW14](../refs/#w) (0 < *T* < 50 °C, 1 < *S* < 50, Seawater scale, real seawater).
+        * `15`: [WMW14](../refs/#w) (0 < *T* < 45 °C, 0 < *S* < 45, Seawater scale, real seawater).
         * `16`: [SLH20](../refs/#s)  (−1.67 < *T* < 31.80 °C, 30.73 < *S* < 37.57, Total scale, field measurements) **(default)**.
-        * `17`: [SB21](../refs/#s) (15 < *T* < 35 °C, 19.6 < *S* < 41, Total scale).
+        * `17`: [SB21](../refs/#s) (15 < *T* < 35 °C, 19.6 < *S* < 41, Total scale, real seawater).
 
     The brackets above show the valid temperature (*T*) and salinity (*S*) ranges, original pH scale, and type of material measured to derive each set of constants.
 
@@ -160,7 +160,7 @@ Each argument to `pyco2.sys` described on this page can either be a single scala
     #### Override equilibrium constants
 
     All the equilibrium constants needed by PyCO2SYS are estimated internally from temperature, salinity and pressure, and returned in the results.  However, you can also directly provide your own values for any of these constants instead.
-    
+
     To do this, the arguments have the same keywords as the corresponding [results dict keys](#equilibrium-constants).  For example, to provide your own water dissociation constant value at input conditions of $10^{-14}$, use `k_water=1e-14`.
 
     If non-zero using `total_alpha` and/or `total_beta`, you should also supply the corresponding stoichiometric dissociation constant values as `k_alpha`/`k_alpha_out` and/or `k_beta`/`k_beta_out`.  If not provided, these default to p*K* = 7.

--- a/docs/co2sys_nd.md
+++ b/docs/co2sys_nd.md
@@ -118,7 +118,7 @@ Each argument to `pyco2.sys` described on this page can either be a single scala
         * `6`: [MCHP73](../refs/#m) aka "GEOSECS" (2 < *T* < 35 °C, 19 < *S* < 43, NBS scale, real seawater).
         * `7`: [MCHP73](../refs/#m) without certain species aka "Peng" (2 < *T* < 35 °C, 19 < *S* < 43, NBS scale, real seawater).
         * `8`: [M79](../refs/#m) (0 < *T* < 50 °C, *S* = 0, freshwater only).
-        * `9`: [CW98](../refs/#c) (2 < *T* < 30 °C, 0 < *S* < 40, NBS scale, real seawater).
+        * `9`: [CW98](../refs/#c) (2 < *T* < 30 °C, 0 < *S* < 40, NBS scale, real estuarine seawater).
         * `10`: [LDK00](../refs/#l) (2 < *T* < 35 °C, 19 < *S* < 43, Total scale, real seawater).
         * `11`: [MM02](../refs/#m) (0 < *T* < 45 °C, 5 < *S* < 42, Seawater scale, real seawater).
         * `12`: [MPL02](../refs/#m) (−1.6 < *T* < 35 °C, 34 < *S* < 37, Seawater scale, field measurements).

--- a/docs/refs.md
+++ b/docs/refs.md
@@ -197,7 +197,7 @@ Click on each reference to see more details.
 
 ### S
 
-??? note "SB21: Schockman & Byrne (2021) *Geochim. Cosmochim. Acta*
+??? note "SB21: Schockman & Byrne (2021) *Geochim. Cosmochim. Acta*"
     Schockman, K. M., and Byrne, R. H. (2021). Spectrophotometric Determination of the Bicarbonate Dissociation Constant in Seawater. *Geochemica Cosmochimica Acta*, in press.  [doi:10.1016/j.gca.2021.02.008](https://doi.org/10.1016/j.gca.2021.02.008).
 
 ??? note "SLH20: Sulpis et al. (2020) *Ocean Sci.*"
@@ -211,7 +211,7 @@ Click on each reference to see more details.
 
 ### T
 
-??? note "TSW09: Takahashi et al. (2009) *Deep-Sea Res. Pt. II*
+??? note "TSW09: Takahashi et al. (2009) *Deep-Sea Res. Pt. II*"
     Takahashi, T., Sutherland, S. C., Wanninkhof, R., Sweeney, C., Feely, R. A., Chipman, D. W., Hales, B., Friederich, G., Chavez, F., Sabine, C., Watson, A., Bakker, D. C. E., Schuster, U., Metzl, N., Yoshikawa-Inoue, H., Ishii, M., Midorikawa, T., Nojiri, Y., Körtzinger, A., Steinhoff, T., Hoppema, M., Olafsson, J., Arnarson, T. S., Tilbrook, B., Johannessen, T., Olsen, A., Bellerby, R., Wong, C. S., Delille, B., Bates, N. R., and de Baar, H. J. W. (2009).  Climatological mean and decadal change in surface ocean pCO<sub>2</sub>, and net sea-air CO<sub>2</sub> flux over the global oceans.  *Deep-Sea Research II* 56, 554–577.  [doi:10.1016/j.dsr2.2008.12.009](https://doi.org/10.1016/j.dsr2.2008.12.009).
 
 ??? note "TWB82: Takahashi et al. (1982) in *"GEOSECS Pacific Expedition"*"
@@ -228,7 +228,7 @@ Click on each reference to see more details.
     Weiss, R. F. (1974). Carbon dioxide in water and seawater: the solubility of a non-ideal gas. *Marine Chemistry* 2, 203–215. <a href='https://doi.org/10.1016/0304-4203(74)90015-2'>doi:10.1016/0304-4203(74)90015-2</a>.
 
 ??? note "WM13: Waters & Millero (2013) *Mar. Chem.*"
-    Waters, J.F., Millero, F.J. (2013). The free proton concentration scale for seawater pH. *Marine Chemistry* 149, 8–22. [doi:10.1016/j.marchem.2012.11.003](https://doi.org/10.1016/j.marchem.2012.11.003)
+    Waters, J.F., Millero, F.J. (2013). The free proton concentration scale for seawater pH. *Marine Chemistry* 149, 8–22. [doi:10.1016/j.marchem.2012.11.003](https://doi.org/10.1016/j.marchem.2012.11.003).
 
 ??? note "WMW14: Waters et al. (2014) *Mar. Chem.*"
     Waters, J., Millero, F. J., and Woosley, R. J. (2014). Corrigendum to “The free proton concentration scale for seawater pH”, [MARCHE: 149 (2013) 8–22]. *Marine Chemistry* 165, 66–67. [doi:10.1016/j.marchem.2014.07.004](https://doi.org/10.1016/j.marchem.2014.07.004).

--- a/docs/refs.md
+++ b/docs/refs.md
@@ -227,6 +227,9 @@ Click on each reference to see more details.
 ??? note "W74: Weiss (1974) *Mar. Chem.*"
     Weiss, R. F. (1974). Carbon dioxide in water and seawater: the solubility of a non-ideal gas. *Marine Chemistry* 2, 203–215. <a href='https://doi.org/10.1016/0304-4203(74)90015-2'>doi:10.1016/0304-4203(74)90015-2</a>.
 
+??? note "WM13: Waters & Millero (2013) *Mar. Chem.*"
+    Waters, J.F., Millero, F.J. (2013). The free proton concentration scale for seawater pH. *Marine Chemistry* 149, 8–22. [doi:10.1016/j.marchem.2012.11.003](https://doi.org/10.1016/j.marchem.2012.11.003)
+
 ??? note "WMW14: Waters et al. (2014) *Mar. Chem.*"
     Waters, J., Millero, F. J., and Woosley, R. J. (2014). Corrigendum to “The free proton concentration scale for seawater pH”, [MARCHE: 149 (2013) 8–22]. *Marine Chemistry* 165, 66–67. [doi:10.1016/j.marchem.2014.07.004](https://doi.org/10.1016/j.marchem.2014.07.004).
 


### PR DESCRIPTION
In `docs/refs.md`, reference WM13 was added. It is cited under `opt_k_bisulfate` in `docs/co2sys_nd.md`, but was missing from the reference list.

In `docs/co2sys_nd.md`, changes were made to the descriptions of some of the options for `opt_k_carbonic`. The reasons for these are described below, with the corresponding citations as headers (see `docs/refs.md` for full references).

## CW98

Docs state real and artificial seawater used.
Methods (p. 659) describe collection and analysis of real seawater samples (see screenshot below), but there is no mention of artificial seawater.
![ce69ab167adc494794a2b0e5920d9b46](https://user-images.githubusercontent.com/53826388/118816621-a6610e00-b8b2-11eb-91ba-6d8645e1d3b8.png)

Docs give the ranges 2 < T < 35 °C, 0 < S < 49 for this parameterisation.
Formulae used in the code are shown below (results, p. 661). Note that slightly different temperature ranges are given for the two pK formulae. I suggest using the range in which the two overlap, i.e., 2 < T < 30 °C. Note also the statement at the bottom, that the equations hold for salinities up to 40, not 49.
![07d942b38e6d40e2a384a56ff5266295](https://user-images.githubusercontent.com/53826388/118816749-c7c1fa00-b8b2-11eb-8893-933bfd7511c3.png)

---

## WMW14

Docs state ranges 0 < T < 50 °C, 1 < S < 50.
See highlighted line below (p. 16 in WM13). There is no eqn. 33 in the paper, but the contents of Table 6 (in both WM13 and WMW14) appear to correspond to eqns. 34-35, and these are the functions used in the code, so I believe the ranges stated below should be applied to this parameterisation.
![13454a05465847559a8881230b0ff5de](https://user-images.githubusercontent.com/53826388/118817173-3b640700-b8b3-11eb-9a2f-53f8d125df47.png)

---

## SB21

Type of seawater used is not stated in the docs.
Materials section (p. 233) in the article states it was real seawater:
![c5ed964599c74f83a38a8bedc600cd4d](https://user-images.githubusercontent.com/53826388/118816825-e0321480-b8b2-11eb-9f6e-e143a56ba48f.png)