### PR TITLE
Fix typo in p1atm.py

### DIFF
--- a/PyCO2SYS/equilibria/p1atm.py
+++ b/PyCO2SYS/equilibria/p1atm.py
@@ -280,7 +280,7 @@ def kH2CO3_TOT_RRV93(TempK, Sal):
         - 2307.1266 / TempK
         - 1.5529413 * np.log(TempK)
         + (-0.20760841 - 4.0484 / TempK) * np.sqrt(Sal)
-        + 0.08468345 * Sal
+        + 0.0846834 * Sal
         - 0.00654208 * np.sqrt(Sal) * Sal
     )
     K1 = np.exp(lnK1) * (  # this is on the total pH scale in mol/kg-H2O


### PR DESCRIPTION
An errant '5' seems to have snuck into the code at the end of the number highlighted in the screenshot below (taken from Roy et al., 1996 - amendment to ref. RRV93 in this repo).

![image](https://user-images.githubusercontent.com/53826388/124108299-61f68f80-da66-11eb-9f48-a0eee3aa2d39.png)
