### PR TITLE
Dependabot, pre commit, and ruff configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-ast
+      - id: check-json
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.8.6
+    hooks:
+      # - id: ruff
+      #   name: ruff lint
+      #   args: [--fix, --show-fixes]
+      - id: ruff-format
+  - repo: https://github.com/rbubley/mirrors-prettier # Update mirror as official mirror is deprecated
+    rev: v3.4.2
+    hooks:
+      - id: prettier

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,9 +10,9 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.8.6
     hooks:
-      # - id: ruff
-      #   name: ruff lint
-      #   args: [--fix, --show-fixes]
+      - id: ruff
+        name: ruff lint
+        args: [--fix, --show-fixes]
       - id: ruff-format
   - repo: https://github.com/rbubley/mirrors-prettier # Update mirror as official mirror is deprecated
     rev: v3.4.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,3 +32,9 @@ include = ["PyCO2SYS*"]
 
 [tool.setuptools.dynamic]
 version = {attr = "PyCO2SYS.meta.version"}
+
+[tool.ruff.lint.pydocstyle]
+convention = "numpy"
+
+[tool.ruff.lint.isort]
+known-first-party = ["PyCO2SYS"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ build-backend = "setuptools.build_meta"
 name = "PyCO2SYS"
 description = "PyCO2SYS: marine carbonate system calculations in Python"
 readme = "README.md"
+requires-python = ">= 3.10"
 dependencies = [
     "jax",
     "networkx",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,65 @@ include = ["PyCO2SYS*"]
 [tool.setuptools.dynamic]
 version = {attr = "PyCO2SYS.meta.version"}
 
+
+[tool.ruff.lint]
+select = [
+    "D",  # pydocstyle
+    "E",  # Error
+    "F",  # pyflakes
+    "I",  # isort
+    "B",  # Bugbear
+    "UP", # pyupgrade
+    "LOG", # logging
+    "ICN", # import conventions
+    "G", # logging-format
+    "RUF", # ruff
+    "ISC001", # single-line-implicit-string-concatenation
+]
+
+ignore = [
+    # line too long (82 > 79 characters)
+    "E501",
+    # Missing docstring in public module
+    "D100",
+    # Missing docstring in public class
+    "D101",
+    # Missing docstring in public method
+    "D102",
+    # Missing docstring in public function
+    "D103",
+    # Missing docstring in public package
+    "D104",
+    # Missing docstring in magic method
+    "D105",
+    # Missing docstring in __init__
+    "D400",
+    # First line should be in imperative mood (requires writing of summaries)
+    "D401",
+    # First word of docstring is uncapitalized
+    "D403",
+    # First word of the docstring should not be `This`
+    "D404",
+    # 1 blank line required between summary line and description (requires writing of summaries)
+    "D205",
+    # Docstring contains ambiguous...
+    "RUF002",
+
+    # TODO: These should be fixed
+    "B006", # Do not use mutable data structures for argument defaults
+    "B007", # Loop control variable `funcs` not used within loop body
+    "B011", # Do not `assert False`
+    "B028", # No explicit `stacklevel` keyword argument found
+    "B904", # Within an `except` clause, raise exceptions
+    "RUF001", # String contains ambiguous ...
+    "E402", # Module level import not at top of file
+    "E711", # Comparison to `None` should be `cond is None`
+    "E721", # Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
+    "F401", # ... imported but unused; consider removing, adding to `__all__`, or using a redundant alias
+    "ICN", # import conventions
+    "B905", # zip-without-explicit-strict
+]
+
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"
 


### PR DESCRIPTION
This PR adds dependabot, pre-commit and ruff configuration to the codebase. These files (ie, `.github/dependabot.yml`, `.pre-commit-config.yaml` and `pyproject.toml`) are the only places where manual changes have been made, all other changes in this PR are as a result of the included tools.

Let me knwo @mvdh7 if there are any tools/linting rules that you are unsure of